### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,13 +37,12 @@ desc "Release version #{Workarea::Theme::VERSION} of the gem"
 task :release do
   host = "https://#{ENV['BUNDLE_GEMS__WEBLINC__COM']}@gems.weblinc.com"
 
-  #Rake::Task['workarea:changelog'].execute
-  #system 'git add CHANGELOG.md'
-  #system 'git commit -m "Update CHANGELOG"'
-  #system 'git push origin HEAD'
+  Rake::Task['workarea:changelog'].execute
+  system 'git add CHANGELOG.md'
+  system 'git commit -m "Update CHANGELOG"'
 
   system "git tag -a v#{Workarea::Theme::VERSION} -m 'Tagging #{Workarea::Theme::VERSION}'"
-  system 'git push --tags'
+  system 'git push origin HEAD --follow-tags'
 
   system 'gem build workarea-theme.gemspec'
   system "gem push workarea-theme-#{Workarea::Theme::VERSION}.gem"


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

No changelog

WORKAREA-148